### PR TITLE
Revert react-loader-spinner to working version

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "react-helmet": "^6.1.0",
     "react-hot-toast": "^2.3.0",
     "react-icons": "^4.3.1",
-    "react-loader-spinner": "^5.1.5",
+    "react-loader-spinner": "~5.1.5",
     "react-organizational-chart": "^2.1.1",
     "react-qr-code": "^2.0.7",
     "react-redux": "^8.0.1",


### PR DESCRIPTION

# Description

Fixed issue of `react-loader-spinner` failing the build of ReactPlay by downgrading it's version to a stable one.

Fixes #515 

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on local build.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
