### PR TITLE
hackathon banner rwd fix

### DIFF
--- a/src/common/activities/hackathon/HackathonBanner.jsx
+++ b/src/common/activities/hackathon/HackathonBanner.jsx
@@ -18,7 +18,7 @@ function HackathonBanner() {
         <span className="text-lg md:text-xl lg:text-2xl">ReactPlay Presents</span>
         <h1 className=" uppercase text-5xl md:text-6xl lg:text-8xl font-bold text-cyan-300 text-center lg:text-left">
           <span className="sr-only">HACK-R-PLAY</span>
-          <img src={HRPLogo} className="w-64 lg:w-auto ml-auto mr-auto lg:ml-0 lg:mr-0 lg:inline-block" />
+          <img src={HRPLogo} className="w-10/12 md:w-64 lg:w-auto ml-auto mr-auto lg:ml-0 lg:mr-0 lg:inline-block" />
         </h1>
         <div className="my-2 md:my-4 md:text-xl">
           <p className="text-2xl font-bold mt-8 mb-4 text-center lg:text-left">Developers and Hacking are inseparable!</p>

--- a/src/common/activities/hackathon/hackathonBanner.css
+++ b/src/common/activities/hackathon/hackathonBanner.css
@@ -28,3 +28,10 @@
     flex-wrap: wrap;
   }
 }
+
+@media screen and (max-width: 576px) {
+  .app-home-body .body-c2a.body-c2a-hackathon {
+    justify-content: center;
+    flex-wrap: wrap;
+  }
+}


### PR DESCRIPTION
Describe the bug
Lack of responsiveness in main section of Reactplay site after the addition of hackathon page link it breaks in mobile devices.

To Reproduce
Steps to reproduce the behavior:

Go to reactplay (mobile)
You can see the buttons breaking and text overflow.
Expected behavior
It should be responsive in all device's

![image](https://user-images.githubusercontent.com/6359059/193180956-97433c93-cd15-40bb-9329-289b4096cb5d.png)
