### PR TITLE
[feat] Add the number badge to the comment icon 

### DIFF
--- a/src/common/playlists/PlayHeaderActions.jsx
+++ b/src/common/playlists/PlayHeaderActions.jsx
@@ -25,6 +25,7 @@ const PlayHeaderActions = ({ play }) => {
   const [showComment, setShowComment] = useState(false);
   const [likeObj, setLikeObj] = useState({ ...initialLikeObject });
   const [loading, setLoading] = useState(false);
+  const [commentCount, setCommentCount] = useState(0);
   const isAuthenticated = useAuthenticated();
 
   const constructLikeData = useCallback(
@@ -78,11 +79,21 @@ const PlayHeaderActions = ({ play }) => {
     }
   };
 
+  useEffect(() => {
+    (async () => {
+      const { data } = await axios.get(
+        `https://giscus.app/api/discussions?repo=reactplay/react-play&term=${play.path}`
+      );
+      setCommentCount(data.discussion.totalCommentCount);
+    })();
+  }, []);
+
   return (
     <>
       <Like onLikeClick={!loading ? onLikeClick : null} likeObj={likeObj} />
       <button className='action badged' onClick={() => setShowComment(true)}>
         <BiComment className='icon' size='24px' />
+        <div className="badge-count">{commentCount}</div>
         <span className='sr-only'>Comments</span>
       </button>
 

--- a/src/common/playlists/PlayHeaderActions.jsx
+++ b/src/common/playlists/PlayHeaderActions.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useLayoutEffect, useState } from "react";
+import React, { useCallback, useEffect, useLayoutEffect, useState } from "react";
 import { useAuthenticated, useUserId } from "@nhost/react";
 import { BsGithub } from "react-icons/bs";
 import { IoLogoYoutube } from "react-icons/io";
@@ -10,6 +10,7 @@ import Comment from "common/components/Comment";
 import useLikePlays from "common/hooks/useLikePlays";
 import { NHOST } from "common/const";
 import countByProp from "common/utils/countByProp";
+import axios from "axios";
 
 const initialLikeObject = {
   liked: false,


### PR DESCRIPTION
# Description

This PR adds the feature of showing the number badge to the comment icon

Fixes #154 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

This has been tested manually. On opening any play the correct comment count should be displayed.
eg. On opening, React-Gradients play it shows 1

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
