### PR TITLE
Text underline moved to the back 

### DIFF
--- a/src/common/playcreated/play-created.scss
+++ b/src/common/playcreated/play-created.scss
@@ -21,7 +21,6 @@
       content: "";
       position: absolute;
       height: 4px;
-      background-color: var(--color-brand-primary);
       left: 0;
       right: 0;
       bottom: 0.4rem;


### PR DESCRIPTION
# Description

The underline was hiding the text behind. Now it is moved to the back of the text. closes #703 

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I have tested the changes by running them on my local.

# Checklist:

- [x] I have performed a self-review of my own code

