### PR TITLE
[FIX]: removed extra fault payload code in filter

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,4 +1,4 @@
-REACT_APP_NHOST_BACKEND_URL=https://rgkjmwftqtbpayoyolwh.nhost.run/
+REACT_APP_NHOST_BACKEND_URL=https://rgkjmwftqtbpayoyolwh.nhost.run
 REACT_APP_NHOST_VERSION=v1
 REACT_APP_NHOST_ENDPOINT=graphql
 REACT_APP_PLAY_WEB_SVC=https://api.reactplay.io/.netlify/functions/server

--- a/src/common/services/request/query/fetch-plays-filter.js
+++ b/src/common/services/request/query/fetch-plays-filter.js
@@ -14,7 +14,7 @@ function createObjectPayload(items, key, ifTags) {
   if (items.length > 1) {
     obj.clause = {
       operator: 'or',
-      conditions: !env && !preview ? [defaultClause] : []
+      conditions: []
     };
     if (ifTags) {
       obj.clause.class = 'play_tags';


### PR DESCRIPTION
# Description

While creating the JSON payload for filtering plays based on multiple filters, we add a conditional clause for the production environment. This clause helps us remove the plays that are in `dev_mode`.
The conditional clause was incorrectly added in 2 places.

- Fixes #867 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
I have verified it by setting the `env` conditions to mimic the activity on production.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
