### PR TITLE
Updated the npm command to run cypress locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ yarn cypress:open
 ```
 OR
 ```
-npm cypress:open
+npm run cypress:open
 ```
 
 It will open the cypress dashboard, through which you need to select `E2E Testing`.


### PR DESCRIPTION
# Description

I updated the readme section. The npm command to run cypress locally was `npm cypress:open` which is wrong, I changed it to `npm run cypress:open`.

Fixes # ([issue](https://github.com/reactplay/react-play/issues/1043))

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I ran the command on my local machine and it worked. To reproduce, follow the steps in the readme.

# Checklist:
- [ ] My changes generate no new warnings
