### PR TITLE
Fix: button text in center (#1107)

### DIFF
--- a/src/common/home/home.css
+++ b/src/common/home/home.css
@@ -170,6 +170,11 @@
     flex-direction: column;
     width: 80%;
   }
+
+  .app-home-body .body-c2a .body-c2a-btn {
+    display: flex;
+    justify-content: center;
+  }
 }
 
 /* Video */


### PR DESCRIPTION
> First thing, PLEASE READ THIS: [ReactPlay Code Review Checklist](https://github.com/reactplay/react-play/wiki/ReactPlay-Code-Review-Checklist)

# Description
Button text is centered on mobile screen lesser than 576px.
<img width="407" alt="Screenshot 2023-04-13 at 11 58 44 PM" src="https://user-images.githubusercontent.com/46367738/231850765-73bbaba6-2a35-4109-a0be-c8a5b1333e81.png">

Fixes # 1107

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Screenshots or example output
<img width="411" alt="Screenshot 2023-04-13 at 11 57 42 PM" src="https://user-images.githubusercontent.com/46367738/231850530-c3a2560b-97f4-468b-9114-c5d51606642b.png">

