### PR TITLE
fix an issue with wordle-game play: unable to start a new game

### DIFF
--- a/src/plays/wordle/Wordle.tsx
+++ b/src/plays/wordle/Wordle.tsx
@@ -71,6 +71,7 @@ function Wordle(props: any): JSX.Element {
     // This method removes all children from element node
     errorSlideRef.current.replaceChildren();
     setStats(null);
+    setGameOver(false);
   }
 
   function pushError(string: string) {
@@ -254,6 +255,7 @@ function Wordle(props: any): JSX.Element {
                   {'QWERTYUIOP'.split('').map((alphabet) => (
                     <KeyboardKey
                       alphabet={alphabet}
+                      key={alphabet}
                       letterStatus={letterStatus}
                       onKeyClick={onKeyClick}
                     />
@@ -264,6 +266,7 @@ function Wordle(props: any): JSX.Element {
                   {'ASDFGHJKL'.split('').map((alphabet) => (
                     <KeyboardKey
                       alphabet={alphabet}
+                      key={alphabet}
                       letterStatus={letterStatus}
                       onKeyClick={onKeyClick}
                     />
@@ -285,6 +288,7 @@ function Wordle(props: any): JSX.Element {
                     return (
                       <KeyboardKey
                         alphabet={alphabet}
+                        key={alphabet}
                         letterStatus={letterStatus}
                         onKeyClick={onKeyClick}
                       />

--- a/src/plays/wordle/components/WordleRow.tsx
+++ b/src/plays/wordle/components/WordleRow.tsx
@@ -26,6 +26,7 @@ export default function WordleRow(props: { tileRow: TileRow; wordleWord: string 
                   roll
                   correct={isCorrect}
                   index={index}
+                  key={`${index}-${letter}`}
                   style={TileColor.CORRECT}
                   tile={letter}
                 />
@@ -39,6 +40,7 @@ export default function WordleRow(props: { tileRow: TileRow; wordleWord: string 
                   roll
                   correct={isCorrect}
                   index={index}
+                  key={`${index}-${letter}`}
                   style={TileColor.MISPLACED}
                   tile={letter}
                 />
@@ -49,6 +51,7 @@ export default function WordleRow(props: { tileRow: TileRow; wordleWord: string 
                   roll
                   correct={isCorrect}
                   index={index}
+                  key={`${index}-${letter}`}
                   style={TileColor.WRONG}
                   tile={letter}
                 />
@@ -60,6 +63,7 @@ export default function WordleRow(props: { tileRow: TileRow; wordleWord: string 
               <WordleTile
                 correct={isCorrect}
                 index={index}
+                key={`${index}-${letter}`}
                 roll={false}
                 style={TileColor.MISPLACED}
                 tile={letter}

--- a/src/plays/wordle/components/WordleRow.tsx
+++ b/src/plays/wordle/components/WordleRow.tsx
@@ -26,7 +26,7 @@ export default function WordleRow(props: { tileRow: TileRow; wordleWord: string 
                   roll
                   correct={isCorrect}
                   index={index}
-                  key={`${index}-${letter}`}
+                  key={crypto.randomUUID()}
                   style={TileColor.CORRECT}
                   tile={letter}
                 />
@@ -40,7 +40,7 @@ export default function WordleRow(props: { tileRow: TileRow; wordleWord: string 
                   roll
                   correct={isCorrect}
                   index={index}
-                  key={`${index}-${letter}`}
+                  key={crypto.randomUUID()}
                   style={TileColor.MISPLACED}
                   tile={letter}
                 />
@@ -51,7 +51,7 @@ export default function WordleRow(props: { tileRow: TileRow; wordleWord: string 
                   roll
                   correct={isCorrect}
                   index={index}
-                  key={`${index}-${letter}`}
+                  key={crypto.randomUUID()}
                   style={TileColor.WRONG}
                   tile={letter}
                 />
@@ -63,7 +63,7 @@ export default function WordleRow(props: { tileRow: TileRow; wordleWord: string 
               <WordleTile
                 correct={isCorrect}
                 index={index}
-                key={`${index}-${letter}`}
+                key={crypto.randomUUID()}
                 roll={false}
                 style={TileColor.MISPLACED}
                 tile={letter}


### PR DESCRIPTION
> First thing, PLEASE READ THIS: [ReactPlay Code Review Checklist](https://github.com/reactplay/react-play/wiki/ReactPlay-Code-Review-Checklist)

# Description

> Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

This commit fixes an issue with Wordle Game Play where you are unable to enter new words after starting a new game.
The `gameOver` state will now be set to false when the component state resets.
Also, add missing key prop to iterative components of Wordle Row.

Fixes #1188

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Project was locally tested on my system, including the parts where the changes will be made.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings