### PR TITLE
refactor LevelBadge to remove redundant usages of useState &useEffect

### DIFF
--- a/src/common/components/LevelBadge.jsx
+++ b/src/common/components/LevelBadge.jsx
@@ -1,47 +1,30 @@
-import { useState, useEffect } from 'react';
 import { RiMedal2Fill } from 'react-icons/ri';
 import { IoMdTrophy } from 'react-icons/io';
 import { IoRibbon } from 'react-icons/io5';
 
 const LevelBadge = ({ level }) => {
-  const [playLevel, setPlayLevel] = useState(null);
+  switch (level) {
+    case 'Intermediate':
+      return (
+        <span className="play-level play-level-2">
+          <RiMedal2Fill size="16px" /> {level}
+        </span>
+      );
 
-  useEffect(() => {
-    switch (level) {
-      case 'Beginner':
-        setPlayLevel(
-          <span className="play-level play-level-1">
-            <IoRibbon size="16px" /> {level}
-          </span>
-        );
-
-        break;
-      case 'Intermediate':
-        setPlayLevel(
-          <span className="play-level play-level-2">
-            <RiMedal2Fill size="16px" /> {level}
-          </span>
-        );
-
-        break;
-      case 'Advanced':
-        setPlayLevel(
-          <span className="play-level play-level-3">
-            <IoMdTrophy size="16px" /> {level}
-          </span>
-        );
-
-        break;
-      default:
-        setPlayLevel(
-          <span className="play-level play-level-1">
-            <IoRibbon size="16px" /> {level}
-          </span>
-        );
-    }
-  }, [level]);
-
-  return <>{playLevel}</>;
+    case 'Advanced':
+      return (
+        <span className="play-level play-level-3">
+          <IoMdTrophy size="16px" /> {level}
+        </span>
+      );
+    case 'Beginner':
+    default:
+      return (
+        <span className="play-level play-level-1">
+          <IoRibbon size="16px" /> {level}
+        </span>
+      );
+  }
 };
 
 export default LevelBadge;


### PR DESCRIPTION

> First thing, PLEASE READ THIS: [ReactPlay Code Review Checklist](https://github.com/reactplay/react-play/wiki/ReactPlay-Code-Review-Checklist)

# Description

LevelBadge component was using `useState` and `useEffect` hook when neither of them were needed. Refactored out usage of both the hooks in this PR

Fixes https://github.com/reactplay/react-play/issues/1225

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Screenshots or example output

<!--- If you made any visual changes, include screenshot. -->
<!-- If you made any workflow changes, include a screenshare -->
<!--- If not relevant, delete this section. -->
