### PR TITLE
[Fix] Search & Filter issue

### DIFF
--- a/src/common/search/FilterPlays.jsx
+++ b/src/common/search/FilterPlays.jsx
@@ -108,17 +108,8 @@ const FilterPlays = ({ onChange, query }) => {
         finalQueryObject[key] = res[key];
       }
     });
-    const final_query = { ...finalQueryObject };
-    const final_query_param = new URLSearchParams(finalQueryObject).toString();
-
-    if (final_query_param) {
-      setShowModal(false);
-    } else {
-      setShowModal(true);
-    }
-    if (onChange) {
-      onChange(final_query);
-    }
+    setShowModal(false);
+    onChange({ ...finalQueryObject });
   };
 
   const handleChange = (key, value) => {

--- a/src/common/search/FilterPlays.jsx
+++ b/src/common/search/FilterPlays.jsx
@@ -109,9 +109,9 @@ const FilterPlays = ({ onChange, query }) => {
       }
     });
     const final_query = { ...finalQueryObject };
-    const fianl_query_param = new URLSearchParams(finalQueryObject).toString();
+    const final_query_param = new URLSearchParams(finalQueryObject).toString();
 
-    if (fianl_query_param) {
+    if (final_query_param) {
       setShowModal(false);
     } else {
       setShowModal(true);

--- a/src/common/search/SearchBox.jsx
+++ b/src/common/search/SearchBox.jsx
@@ -11,7 +11,7 @@ export const SearchBox = ({ reset }) => {
   const location = useLocation();
   const navigate = useNavigate();
   useEffect(() => {
-    const p_query = ParseQuery(location.search);
+    const p_query = ParseQuery(location.search) || {};
     setQuery(p_query);
   }, [location.pathname, location.search]);
 
@@ -22,7 +22,7 @@ export const SearchBox = ({ reset }) => {
   };
 
   const onClearFilter = () => {
-    setQuery(undefined);
+    setQuery({});
     navigate(`/plays`);
   };
 

--- a/src/common/search/SearchPlays.jsx
+++ b/src/common/search/SearchPlays.jsx
@@ -18,19 +18,21 @@ const SearchPlays = ({ reset, query, onChange }) => {
     if (reset.search) {
       resetSearchField();
     }
-    const text = query && query.text ? query.text.split('+').join(' ') : '';
+    const text = query && query?.text ? query.text.split('+').join(' ') : '';
 
     setSearchText(decodeURIComponent(text));
   }, [query]);
 
   const handleSearch = (event) => {
     event.preventDefault();
+    const { value } = event.target;
     if (event.key === 'Enter') {
-      query = query || {};
-      query.text = event.target.value;
-      if (onChange) {
-        onChange(query);
+      if (value) {
+        query.text = value;
+      } else {
+        delete query.text;
       }
+      onChange(query);
     }
   };
 


### PR DESCRIPTION
# Description

Fixes
- Empty Search makes the page forever loading
- The filter popup doesn't close automatically when all filters are cleared and Apply is clicked

Fixes #1271 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- Empty Search makes the page forever loading
  - From Homepage, Click on Browse
  - Click on the search field and hit Enter
  - The page will **NOT** load forever
 
- The filter popup doesn't close automatically when all filters are cleared and Apply is clicked
  - Click on Browse
  - Click the filter icon. The filter popup will open.
  - Type Calculator by tea in the Text field and select Beginner from the Levels field. Click Apply.
  - You'll see only 1 play in the list.
  - Now again open the filter popup and deselect Beginner from the Levels field & clear the Text field and hit Apply
  - You'll be able to see in the background other plays are visible but the **filter popup has auto-closed**.

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Screenshots or example output

https://github.com/reactplay/react-play/assets/95222845/fea49ef2-e246-498c-b22d-5feeb9ecaa79


