### PR TITLE
Fix: Github Actions running on forked repos

### DIFF
--- a/.github/workflows/auto-author-assign.yml
+++ b/.github/workflows/auto-author-assign.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   assign-author:
     runs-on: ubuntu-latest
+    if: github.repository == 'reactplay/react-play'
     steps:
       - uses: toshimaru/auto-author-assign
         with:

--- a/.github/workflows/contributions.yml
+++ b/.github/workflows/contributions.yml
@@ -8,7 +8,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   add-contributors:
-    if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true && github.repository == 'reactplay/react-play'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v6

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -12,6 +12,7 @@ concurrency:
 jobs:
   cypress-run:
     runs-on: ubuntu-latest
+    if: github.repository == 'reactplay/react-play'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -27,7 +28,7 @@ jobs:
           install-command: |
             npm install --legacy-peer-deps
           start: npm start
-          wait-on: "http://localhost:3000"
+          wait-on: 'http://localhost:3000'
           browser: chrome
         env:
           # pass GitHub token to detect new build vs re-run build

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -28,7 +28,7 @@ jobs:
           install-command: |
             npm install --legacy-peer-deps
           start: npm start
-          wait-on: 'http://localhost:3000'
+          wait-on: "http://localhost:3000"
           browser: chrome
         env:
           # pass GitHub token to detect new build vs re-run build

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -11,6 +11,7 @@ concurrency:
 jobs:
   welcome:
     runs-on: ubuntu-latest
+    if: github.repository == 'reactplay/react-play'
     steps:
       - uses: actions/checkout@v4
       - uses: EddieHubCommunity/gh-action-community/src/welcome@main

--- a/.github/workflows/stale-issue-and-pr.yml
+++ b/.github/workflows/stale-issue-and-pr.yml
@@ -12,6 +12,7 @@ jobs:
   stale:
     name: 🧹 Clean up stale issues and PRs
     runs-on: ubuntu-latest
+    if: github.repository == 'reactplay/react-play'
     steps:
       - name: 🚀 Stale Issue And PR
         uses: actions/stale@v8


### PR DESCRIPTION
# Description

The Github actions intended to run on this repo `reactplay/react-play`
are also running on forked repo `<username>/react-play`

Fixes #1307 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

This can only be tested after merging.
I've referred [Stop github actions running on a fork](https://github.com/orgs/community/discussions/26704) for fixing this

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
