### PR TITLE
feat: updated GitHub star count number format

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -652,6 +652,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "freemrl",
+      "name": "Jannik Schmidtke",
+      "avatar_url": "https://avatars.githubusercontent.com/u/66525499?v=4",
+      "profile": "https://github.com/FreemRL",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
     ]
   },
   "devDependencies": {
+    "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "@types/dompurify": "^3.0.2",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^5.41.0",

--- a/src/common/activities/ActivityBanner.jsx
+++ b/src/common/activities/ActivityBanner.jsx
@@ -9,6 +9,7 @@ import { UMAMI_EVENTS } from 'constants';
 
 function ActivityBanner({ currentActivity }) {
   const { data } = useFetch(`${process.env.REACT_APP_PLAY_API_URL}/react-play`);
+  const formatter = Intl.NumberFormat('en', { notation: 'compact' });
   const activity = activities.filter((a) => a.id === currentActivity);
   const { name, subtitle, description, logo, heroImage } = activity[0];
 
@@ -50,7 +51,8 @@ function ActivityBanner({ currentActivity }) {
               <span className="btn-label">
                 GitHub{' '}
                 <div className="label-info-more">
-                  <FiStar /> <div className="more-label">{data.stargazers_count}</div>
+                  <FiStar />{' '}
+                  <div className="more-label">{formatter.format(data.stargazers_count)}</div>
                 </div>{' '}
               </span>
             </a>

--- a/src/common/defaultBanner/DefaultBanner.jsx
+++ b/src/common/defaultBanner/DefaultBanner.jsx
@@ -8,6 +8,7 @@ import { UMAMI_EVENTS } from 'constants';
 
 const DefaultBanner = () => {
   const { data } = useFetch(`${process.env.REACT_APP_PLAY_API_URL}/react-play`);
+  const formatter = Intl.NumberFormat('en', { notation: 'compact' });
 
   return (
     <div>
@@ -36,7 +37,7 @@ const DefaultBanner = () => {
           <span className="btn-label">
             GitHub{' '}
             <div className="label-info-more">
-              <FiStar /> <div className="more-label">{data.stargazers_count}</div>
+              <FiStar /> <div className="more-label">{formatter.format(data.stargazers_count)}</div>
             </div>{' '}
           </span>
         </a>


### PR DESCRIPTION
# Description

I changed the GitHub star count number format to show numbers in a more efficient way --> e.g. `1.1K`, `1.1M` etc.

Fixes #1320 

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I used the development server to test functionality. `yarn start`.

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules

# Screenshots or example output

Before:

![before](https://github.com/reactplay/react-play/assets/66525499/e7ddb12b-3ed3-4dd1-ba2d-e0f48125c504)


After:

![after](https://github.com/reactplay/react-play/assets/66525499/cc56393e-ab3c-4cfe-a106-b2a37bdb0731)


