### PR TITLE
fix: bug fix for favicon not visible on new tabs/plays

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" href="./favicon.ico" />
+    <link rel="icon" href="/favicon.ico" />
     <link rel="canonical" href="https://reactplay.io" />
     <link rel="apple-touch-icon" href="./logo.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />


### PR DESCRIPTION
> First thing, PLEASE READ THIS: [ReactPlay Code Review Checklist](https://github.com/reactplay/react-play/wiki/ReactPlay-Code-Review-Checklist)

# Description

This Pull Request addresses a specific issue in the React-Play repository where the favicon was not visible on new tabs during plays. The fix ensures proper visibility of the favicon in such scenarios, enhancing the overall user experience.

Fixes #1383 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Manually tested on multiple browsers to confirm the correct visibility of the favicon on new tabs during plays. Instructions: Clone, checkout, install dependencies, and start the application.

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Screenshots or example output

Chrome:
![chrome](https://github.com/reactplay/react-play/assets/42063201/ec81b9a0-2945-4f10-abdc-a2089995f418)

Edge:
![edge](https://github.com/reactplay/react-play/assets/42063201/af42f508-d9d9-43ff-96ae-4a3ebadcdd4d)

Firefox:
![firefox](https://github.com/reactplay/react-play/assets/42063201/9191897c-6c92-4ac9-83d2-4d665c39518a)

