### PR TITLE
fix(common): focus fix on play filter modal open

### DIFF
--- a/src/common/modal/index.jsx
+++ b/src/common/modal/index.jsx
@@ -1,8 +1,23 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import ReactDOM from 'react-dom';
 import { GoCheck, GoX } from 'react-icons/go';
 
 const Modal = ({ title, show, onClose, onSubmit, children, cname }) => {
+  const modalChildrenRef = useRef(null);
+
+  // useEffect to set the focus on the first focussable element in the modal
+  // when it opens up
+  useEffect(() => {
+    if (show) {
+      const modalChildElements = modalChildrenRef.current;
+      const focusableElements = modalChildElements.querySelectorAll(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      );
+      const firstFocusableElement = focusableElements[0];
+      firstFocusableElement.focus();
+    }
+  }, [show]);
+
   useEffect(() => {
     const close = (e) => {
       // e.keyCode is deprecated: developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode.
@@ -25,7 +40,9 @@ const Modal = ({ title, show, onClose, onSubmit, children, cname }) => {
         <div className={`modal-${cname}-header`}>
           <h2 className="modal-title">{title}</h2>
         </div>
-        <div className={`modal-${cname}-body`}>{children}</div>
+        <div className={`modal-${cname}-body`} ref={modalChildrenRef}>
+          {children}
+        </div>
         <div className={`modal-${cname}-footer`}>
           <button className="btn-default-light btn-size--sm" onClick={onClose}>
             <GoX className="icon" size="16px" /> Cancel

--- a/src/common/modal/index.jsx
+++ b/src/common/modal/index.jsx
@@ -10,11 +10,10 @@ const Modal = ({ title, show, onClose, onSubmit, children, cname }) => {
   useEffect(() => {
     if (show) {
       const modalChildElements = modalChildrenRef.current;
-      const focusableElements = modalChildElements.querySelectorAll(
+      const focusableElements = modalChildElements?.querySelectorAll(
         'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
       );
-      const firstFocusableElement = focusableElements[0];
-      firstFocusableElement.focus();
+      focusableElements?.[0]?.focus();
     }
   }, [show]);
 

--- a/src/common/search/FilterPlays.jsx
+++ b/src/common/search/FilterPlays.jsx
@@ -39,6 +39,14 @@ const FilterPlays = ({ onChange, query }) => {
     }
   }, [query, loading, showModal]);
 
+  // This useEffect ensures that once the filter plays modal is closed, the focus is returned back to the filter plays button
+  useEffect(() => {
+    const filterPlaysBtn = document.getElementById('filterPlaysBtn');
+    if (!showModal && filterPlaysBtn) {
+      filterPlaysBtn.focus();
+    }
+  }, [showModal]);
+
   const filterModalCloseBtnHandler = () => {
     setShowModal(false);
   };
@@ -233,6 +241,7 @@ const FilterPlays = ({ onChange, query }) => {
 
       <button
         className="btn-filter"
+        id="filterPlaysBtn"
         title="Filter Plays"
         onClick={() => {
           showFilterModal();


### PR DESCRIPTION
> First thing, PLEASE READ THIS: [ReactPlay Code Review Checklist](https://github.com/reactplay/react-play/wiki/ReactPlay-Code-Review-Checklist)

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #1414 (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Yes. When you open the filter plays modal now, the focus will be on the first element inside the modal by default. Also, when you close the modal, the focus would go back to the button which opens this modal.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

# Screenshots or example output

<!--- If you made any visual changes, include screenshot. -->
<!-- If you made any workflow changes, include a screenshare -->
<!--- If not relevant, delete this section. -->
