### PR TITLE
fix(plays): remove redundant css to fix bug#1420

### DIFF
--- a/src/plays/schulte-tables/styles.css
+++ b/src/plays/schulte-tables/styles.css
@@ -9,10 +9,6 @@
     flex-direction: column;
 }
 
-h1 {
-    text-align: center;
-}
-
 .game-title {
     text-align: center;
     font-size: 4rem;


### PR DESCRIPTION

> First thing, PLEASE READ THIS: [ReactPlay Code Review Checklist](https://github.com/reactplay/react-play/wiki/ReactPlay-Code-Review-Checklist)

# Description

A css property in a play was causing the h1 to be centre aligned which cause Dynamic Banner Title to be centre aligned.


Fixes #1420 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

I attached the image below.

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

# Screenshots or example output

<img width="1280" alt="Screenshot 2024-01-14 at 1 56 53 PM" src="https://github.com/reactplay/react-play/assets/78199565/def4d10f-4823-41ad-a13b-98f64fb02db1">
