### PR TITLE
refactor: navbar's social icons items

### DIFF
--- a/src/common/header/HeaderNav.jsx
+++ b/src/common/header/HeaderNav.jsx
@@ -30,7 +30,7 @@ const HeaderNav = ({ showBrowse }) => {
 
   const modalClose = () => setShowShareModal(!showShareModal);
 
-  const links = [
+  const NavLinks = [
     {
       type: 'Link',
       testId: 'leaderboard-btn',
@@ -173,24 +173,25 @@ const HeaderNav = ({ showBrowse }) => {
               </a>
             )}
           </li>
-          {links.map((link, index) => {
-            const Component = link.type === 'Link' ? Link : link.type;
+          {NavLinks.map((restNavLink, index) => {
+            const { icon: Icon, ...NavLink } = restNavLink;
+            const Component = NavLink.type === 'Link' ? Link : NavLink.type;
 
             return (
               <li key={index}>
                 <Component
                   className="app-header-btn app-header-btn--default"
-                  data-testid={link.testId}
-                  data-umami-event={link.event}
-                  href={link.href}
+                  data-testid={NavLink.testId}
+                  data-umami-event={NavLink.event}
+                  href={NavLink.href}
                   rel="noopener noreferrer"
                   target="_blank"
-                  title={link.title}
-                  to={link.to}
-                  onClick={link.onClick}
+                  title={NavLink.title}
+                  to={NavLink.to}
+                  onClick={NavLink.onClick}
                 >
-                  <link.icon className={link.iconClass} />
-                  <span className="btn-label">{link.label}</span>
+                  <Icon className={NavLink.iconClass} />
+                  <span className="btn-label">{NavLink.label}</span>
                 </Component>
               </li>
             );

--- a/src/common/header/HeaderNav.jsx
+++ b/src/common/header/HeaderNav.jsx
@@ -30,6 +30,55 @@ const HeaderNav = ({ showBrowse }) => {
 
   const modalClose = () => setShowShareModal(!showShareModal);
 
+  const links = [
+    {
+      type: 'Link',
+      testId: 'leaderboard-btn',
+      title: 'Leader Board',
+      to: '/leaderboard',
+      icon: BsTrophyFill,
+      iconClass: 'icon idea-icon',
+      label: 'Leader Board'
+    },
+    {
+      type: 'Link',
+      testId: 'ideas-btn',
+      title: 'Play Ideas',
+      to: '/ideas',
+      icon: FaLightbulb,
+      iconClass: 'icon idea-icon',
+      label: 'Idea'
+    },
+    {
+      type: 'a',
+      testId: 'github-btn',
+      event: 'github-button',
+      href: 'https://github.com/reactplay/react-play',
+      title: 'GitHub page',
+      icon: BsGithub,
+      iconClass: 'icon github-icon',
+      label: 'GitHub'
+    },
+    {
+      type: 'a',
+      testId: 'twitter-btn',
+      href: 'https://twitter.com/reactplayio',
+      title: 'Twitter Page',
+      icon: FaXTwitter,
+      iconClass: 'icon twitter-icon',
+      label: 'Twitter'
+    },
+    {
+      type: 'button',
+      testId: 'share-btn',
+      title: 'Show love',
+      onClick: handleClick,
+      icon: IoHeartSharp,
+      iconClass: 'icon share-icon',
+      label: 'Share'
+    }
+  ];
+
   return (
     <nav>
       <Modal open={showShareModal} onClose={modalClose}>
@@ -124,66 +173,28 @@ const HeaderNav = ({ showBrowse }) => {
               </a>
             )}
           </li>
-          <li>
-            <Link
-              className="app-header-btn app-header-btn--default"
-              data-testid="leaderboard-btn"
-              title="Leader Board"
-              to="/leaderboard"
-            >
-              <BsTrophyFill className="icon idea-icon" />
-              <span className="btn-label">Leader Board</span>
-            </Link>
-          </li>
-          <li>
-            <Link
-              className="app-header-btn app-header-btn--default"
-              data-testid="ideas-btn"
-              title="Play Ideas"
-              to="/ideas"
-            >
-              <FaLightbulb className="icon idea-icon" />
-              <span className="btn-label">Idea</span>
-            </Link>
-          </li>
-          <li>
-            <a
-              className="app-header-btn app-header-btn--default"
-              data-testid="github-btn"
-              data-umami-event="github-button"
-              href="https://github.com/reactplay/react-play"
-              rel="noopener noreferrer"
-              target="_blank"
-              title="GitHub page"
-            >
-              <BsGithub className="icon github-icon" />
-              <span className="btn-label">GitHub</span>
-            </a>
-          </li>
-          <li>
-            <a
-              className="app-header-btn app-header-btn--default"
-              data-testid="twitter-btn"
-              href="https://twitter.com/reactplayio"
-              rel="noopener noreferrer"
-              target="_blank"
-              title="Twitter Page"
-            >
-              <FaXTwitter className="icon twitter-icon" />
-              <span className="btn-label">Twitter</span>
-            </a>
-          </li>
-          <li>
-            <button
-              className="app-header-btn app-header-btn--default"
-              data-testid="share-btn"
-              title="Show love"
-              onClick={handleClick}
-            >
-              <IoHeartSharp className="icon share-icon" />
-              <span className="btn-label">Share</span>
-            </button>
-          </li>
+          {links.map((link, index) => {
+            const Component = link.type === 'Link' ? Link : link.type;
+
+            return (
+              <li key={index}>
+                <Component
+                  className="app-header-btn app-header-btn--default"
+                  data-testid={link.testId}
+                  data-umami-event={link.event}
+                  href={link.href}
+                  rel="noopener noreferrer"
+                  target="_blank"
+                  title={link.title}
+                  to={link.to}
+                  onClick={link.onClick}
+                >
+                  <link.icon className={link.iconClass} />
+                  <span className="btn-label">{link.label}</span>
+                </Component>
+              </li>
+            );
+          })}
           <Menu anchorEl={anchorEl} open={open} onClose={handleClose}>
             <Box sx={{ p: 4, pt: 2, borderRadius: 2, width: '360px' }}>
               <h3 className="section-title">Show Love</h3>


### PR DESCRIPTION
# Description

Refactor the navbar's social icons code. Removed the repetition part, and instead of that used the mapping to display all icons.

Fixes #1448 

## Type of change

- Code Refactoring

# How Has This Been Tested?

- Tested this change over Chrome Browser and Microsoft Edge

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

# Screenshots or example output

![image](https://github.com/reactplay/react-play/assets/91705825/5474353e-39b4-4ec2-96cf-ab4f3189eef0)
