### PR TITLE
fix(ui): resolve footer position bug

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -123,7 +123,7 @@ body * {
 }
 
 .app-container {
-  height: 100%;
+  height: 100vh;
   display: flex;
   flex-direction: column;
 }


### PR DESCRIPTION
# Description
Changed root container height property to always fill up the page.

Fixes #1450 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I checked that the problem was indeed solved and the footer container looks the same in all of them

# Screenshots or example output
Before             |  After
:-------------------------:|:-------------------------:
![](https://github.com/reactplay/react-play/assets/94786579/0cf4c471-6f00-4f19-b9b6-96348dde7f1e)  |  ![](https://github.com/reactplay/react-play/assets/94786579/9d0bfb43-367e-4d5b-9ab8-e40ad993cdf8)
