### PR TITLE
Add border to the play card on the home page

### DIFF
--- a/src/common/playlists/playlist.css
+++ b/src/common/playlists/playlist.css
@@ -829,13 +829,18 @@
 .play-card-container {
   display: flex;
   flex-direction: column;
-  border: 1px solid #ddd;
+  border: 2px solid #757575;
   border-radius: 8px;
   overflow: hidden;
   transition: transform 0.2s ease-in-out;
   width: 300px;
   height: 100%;
   padding: 12px;
+}
+
+.play-card-container:hover {
+  transform: scale(105%);
+  transition: transform 0.2s ease-in-out;
 }
 
 .border {


### PR DESCRIPTION
> First thing, PLEASE READ THIS: [ReactPlay Code Review Checklist](https://github.com/reactplay/react-play/wiki/ReactPlay-Code-Review-Checklist)

# Description

Implemented a solution for the visibility issue by adding a border and a hover effect to each card on the homepage. This change has significantly improved the ability to distinguish between the cards, making navigation and identification much clearer.

Fixes #1477 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I test it on my local machine, it is a css modification and is working fine.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

# Screenshots or example output

<img width="1353" alt="Screenshot 2024-03-06 at 5 06 06 PM" src="https://github.com/reactplay/react-play/assets/97306013/857fde47-326d-4be6-8839-833500d81577">

<img width="1391" alt="Screenshot 2024-03-06 at 5 07 04 PM" src="https://github.com/reactplay/react-play/assets/97306013/d71c6a02-a0c0-48c9-82d4-86b2759951a3">



