### PR TITLE
fix: hover behavior in trending plays

### DIFF
--- a/src/common/playlists/playlist.css
+++ b/src/common/playlists/playlist.css
@@ -827,6 +827,7 @@
 }
 
 .play-card-container {
+  position: relative;
   display: flex;
   flex-direction: column;
   border: 2px solid #757575;


### PR DESCRIPTION
Add 'position: relative' to .play-card-container class.

Previously, hovering over the Trending Plays cards didn't  activate the on-hover action until the cursor passed the  middle of the box. This was due to the positioning of the  .play-card-container class. This commit adds 'position: relative'  to the .play-card-container class, ensuring immediate  activation of the on-hover action anywhere inside the box  in the Trending Plays cards.

Issue: #1480

> First thing, PLEASE READ THIS: [ReactPlay Code Review Checklist](https://github.com/reactplay/react-play/wiki/ReactPlay-Code-Review-Checklist)

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

# Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Screenshots or example output

<!--- If you made any visual changes, include screenshot. -->
<!-- If you made any workflow changes, include a screenshare -->
<!--- If not relevant, delete this section. -->
