### PR TITLE
Remove fixed widths of flex

### DIFF
--- a/src/plays/schulte-tables/styles.css
+++ b/src/plays/schulte-tables/styles.css
@@ -31,7 +31,6 @@
 
 .flex {
   display: flex;
-  width: 300px;
   margin: 0 auto;
   justify-content: space-between;
 }


### PR DESCRIPTION
# Description
Removed the width property from the flex class.

Fixes #1508 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Run ReactPlay locally
- Click on the Create Play button
- There will be a create play form which previously took 300px, but now it is properly adjusted to the screen width.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

# Screenshots or example output

![image](https://github.com/user-attachments/assets/4c270f35-6ce6-4b29-ae7e-6153cbf3fcd5)
