### PR TITLE
fix: styling with filter owner (#1518)

### DIFF
--- a/src/common/search/FilterPlays.jsx
+++ b/src/common/search/FilterPlays.jsx
@@ -164,8 +164,12 @@ const FilterPlays = ({ onChange, query }) => {
                   icon={icon}
                   style={{ padding: 0 }}
                 />
-                <div className="flex md-ml-8 min-w-0 ml-2 items-center">
-                  <span className="rounded-full">
+                <div
+                  className={`flex md-ml-8 min-w-0 ml-2 ${field.datafield == 'creators' ? '!justify-start w-full' : null} items-center`}
+                >
+                  <span
+                    className={`${field.datafield == 'creators' ? 'ml-4 mr-3' : null} rounded-full`}
+                  >
                     {field.avatar && getOptionNode(field, option)[field.avatar] ? (
                       <span className="flex items-center justify-center md-h-12 h-8 md-w-16 w-8 mr-4">
                         <img
@@ -176,7 +180,14 @@ const FilterPlays = ({ onChange, query }) => {
                       </span>
                     ) : null}
                   </span>
-                  <span className="break-words min-w-0">
+                  <span
+                    className={`break-words min-w-0 ${field.datafield == 'creators' ? 'truncate' : null}`}
+                    title={
+                      field.datafield == 'creators' && field.node
+                        ? option[field.node][field.fieldName]
+                        : ''
+                    }
+                  >
                     {field.node ? option[field.node][field.fieldName] : option[field.fieldName]}
                   </span>
                 </div>


### PR DESCRIPTION
# Description

Fix styling with filter modal owner, and add tooltip on hover over display names.

Fixes (#1518)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I checked that the problem was solved and the filter modal `owner` the same in all of them.

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Screenshots or example output
|Before|After|
|-|-|
|<img width="832" alt="Screenshot 2024-10-01 at 22 18 10" src="https://github.com/user-attachments/assets/9e3fcb05-e4bd-4d6d-a0b2-3f2c000c51ff">|<img width="703" alt="react-play-1" src="https://github.com/user-attachments/assets/a20991de-7eda-44da-9bf2-5fa912bbb767">|
