### PR TITLE
Fix code scanning alert no. 3: DOM text reinterpreted as HTML

### DIFF
--- a/src/plays/custommemesgenerator/Meme.jsx
+++ b/src/plays/custommemesgenerator/Meme.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import axios from 'axios';
+import DOMPurify from 'dompurify';
 
 export default function Meme() {
   const [memesData, setMemesData] = useState([]);
@@ -27,6 +28,7 @@ export default function Meme() {
     const memesArray = memesData;
     let randomIndex = Math.floor(Math.random() * memesArray.length);
     let newUrl = memesArray[randomIndex].url;
+    newUrl = DOMPurify.sanitize(newUrl);
 
     setMeme((prevMeme) => ({
       ...prevMeme,


### PR DESCRIPTION
Fixes [https://github.com/reactplay/react-play/security/code-scanning/3](https://github.com/reactplay/react-play/security/code-scanning/3)

To fix the problem, we need to ensure that the URL used in the `src` attribute of the `img` tag is sanitized and validated to prevent any potential XSS attacks. We can use a library like `DOMPurify` to sanitize the URL before setting it in the state.

1. Install the `DOMPurify` library to sanitize the URL.
2. Import `DOMPurify` in the `Meme.jsx` file.
3. Sanitize the `newUrl` before updating the state with it.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
