### PR TITLE
Fix code scanning alert no. 8: DOM text reinterpreted as HTML

### DIFF
--- a/src/plays/sticky-notes/components/Note.jsx
+++ b/src/plays/sticky-notes/components/Note.jsx
@@ -11,7 +11,7 @@ const Note = ({ note, handleDelete, handleEdit }) => {
       <p className="text-white capitalize text-lg pt-2">{note.body}</p>
       <a
         className="pt-5 mt-auto block text-blue-900"
-        href={`https://twitter.com/intent/tweet?text="${note.body}`}
+        href={`https://twitter.com/intent/tweet?text="${encodeURIComponent(note.body)}`}
         rel="noreferrer"
         target="_blank"
       >


### PR DESCRIPTION
Fixes [https://github.com/reactplay/react-play/security/code-scanning/8](https://github.com/reactplay/react-play/security/code-scanning/8)

To fix the problem, we need to ensure that the `note.body` content is properly encoded before being inserted into the `href` attribute. This can be achieved by using a library like `encodeURIComponent` to encode the text, which will prevent any malicious content from being interpreted as HTML.

- We will update the `href` attribute in the `Note` component to use `encodeURIComponent(note.body)`.
- This change will be made in the `src/plays/sticky-notes/components/Note.jsx` file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
