### PR TITLE
Fix code scanning alert no. 6: DOM text reinterpreted as HTML

### DIFF
--- a/src/plays/personal-profile-card/components/profile-form.tsx
+++ b/src/plays/personal-profile-card/components/profile-form.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import DOMPurify from 'dompurify';
 
 import ProfileType from '../types';
 import placeholder_cover from '../images/placeholder_cover.jpg';
@@ -27,7 +28,7 @@ const ProfileForm = ({ value, profile, onChange, onClick, onUpload, onClear }: P
         <img
           alt={value.cover === '' ? 'placeholder cover' : 'cover'}
           className="w-full md:w-[600px] h-[150px] sm:h-[200px] rounded-3xl"
-          src={value.cover === '' ? placeholder_cover : value.cover}
+          src={value.cover === '' ? placeholder_cover : DOMPurify.sanitize(value.cover)}
         />
         <input
           accept="image/*"


### PR DESCRIPTION
Fixes [https://github.com/reactplay/react-play/security/code-scanning/6](https://github.com/reactplay/react-play/security/code-scanning/6)

To fix the problem, we need to ensure that the `value.cover` is properly sanitized before being used as the `src` attribute of an `img` tag. One way to achieve this is by using a library like `DOMPurify` to sanitize the input. This will ensure that any potentially malicious content is removed before it is used in the DOM.

1. Install the `DOMPurify` library.
2. Import `DOMPurify` in the relevant file.
3. Use `DOMPurify.sanitize` to sanitize the `value.cover` before using it as the `src` attribute.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
