### PR TITLE
Fix code scanning alert no. 9: Client-side URL redirect

### DIFF
--- a/src/common/Testimonial/TestimonialCard.jsx
+++ b/src/common/Testimonial/TestimonialCard.jsx
@@ -14,11 +14,14 @@ const TestimonialCard = ({ home, quote, name, avatarUrl, category, created_at, e
   });
 
   const getHostName = () => {
-    var url = window.location.href;
-    var arr = url.split('/');
-    var result = arr[0] + '//' + arr[2];
-
-    return result;
+    const allowedHostnames = ['example.com', 'another-example.com'];
+    const url = new URL(window.location.href);
+    if (allowedHostnames.includes(url.hostname)) {
+      return `${url.protocol}//${url.hostname}`;
+    } else {
+      console.error('Hostname not allowed:', url.hostname);
+      return 'https://example.com'; // Safe default value
+    }
   };
 
   function replaceWithBr() {


### PR DESCRIPTION
Fixes [https://github.com/reactplay/react-play/security/code-scanning/9](https://github.com/reactplay/react-play/security/code-scanning/9)

To fix the problem, we should avoid using `window.location.href` directly to construct URLs. Instead, we can use a predefined list of allowed hostnames and validate the current hostname against this list. If the hostname is not in the list, we should not construct the URL.

1. Create a list of allowed hostnames.
2. Modify the `getHostName` function to check if the current hostname is in the allowed list.
3. If the hostname is not allowed, return a safe default value or handle the error appropriately.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
