### PR TITLE
fix: total value shows NaN when an expense with 0 amount

### DIFF
--- a/src/plays/expenses-tracker/ExpensesTracker.tsx
+++ b/src/plays/expenses-tracker/ExpensesTracker.tsx
@@ -20,9 +20,14 @@ function ExpensesTracker(props: any) {
 
   const handleNewExpense = () => {
     const expense = localStoreExpenses[localStoreExpenses.length - 1];
-    data['id'] = expense !== undefined ? parseInt(expense.id) + 1 : 1;
-    setLocalStoreExpenses([...localStoreExpenses, data]);
-    setLocalStoreTotal(parseFloat(localStoreTotal) + parseFloat(data.amount));
+    // Ensure `amount` has a default value of 0 if not present
+    const sanitizedData = {
+      ...data,
+      amount: data.amount || 0
+    };
+    sanitizedData['id'] = expense !== undefined ? parseInt(expense.id) + 1 : 1;
+    setLocalStoreExpenses([...localStoreExpenses, sanitizedData]);
+    setLocalStoreTotal(parseFloat(localStoreTotal) + parseFloat(sanitizedData.amount));
     setOpen(false);
     setData(null);
   };
@@ -97,14 +102,14 @@ function ExpensesTracker(props: any) {
                             <td className="p-1 text-center">{expense.date}</td>
                             <td className="p-1 text-center">{expense.amount}</td>
                             <td className="p-1 flex justify-center space-x-2">
-                              <div className="bg-green-500 rounded-full p-[6px]">
+                              <div className="bg-green-500 cursor-pointer  rounded-full p-[6px]">
                                 <FiEdit
                                   className="text-white"
                                   size={16}
                                   onClick={() => openEditModal(expense)}
                                 />
                               </div>
-                              <div className="bg-red-500 rounded-full p-[6px]">
+                              <div className="bg-red-500 cursor-pointer rounded-full p-[6px]">
                                 <AiOutlineDelete
                                   className="text-white"
                                   size={16}


### PR DESCRIPTION
> First thing, PLEASE READ THIS: [ReactPlay Code Review Checklist](https://github.com/reactplay/react-play/wiki/ReactPlay-Code-Review-Checklist)

# Description

**Summary of the Change:**

1. Resolved an issue where adding an expense with the Amount field set to 0 or left blank resulted in the total value being displayed as NaN. This fix ensures the amount field defaults to 0 if it is not provided.
2. Added the cursor pointer style to the edit and delete buttons to enhance the user experience by providing a visual indicator of interactivity.

**Issue Fixed:**
When adding an expense without specifying the amount field, the total displayed was NaN instead of the expected numeric value. This disrupted the accuracy of expense calculations in the tracker.

Fixes #1573

## Type of change

- [x] fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Verified that adding an expense with the amount field set to 0 or left blank updates the total correctly without displaying NaN.
- Tested with various edge cases, such as:  
     - Adding multiple expenses with and without valid amounts.  
     - Omitting the `Amount` field entirely.  
     - Entering invalid inputs (e.g., strings or special characters).  

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Screenshots or example output

https://github.com/user-attachments/assets/b520f770-3696-43a4-bc0f-e06efa73423c


