### PR TITLE
Added Contributor Guidelines confirmation checkbox to templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/#2PlaysAMonth.yml
+++ b/.github/ISSUE_TEMPLATE/#2PlaysAMonth.yml
@@ -3,6 +3,15 @@ description: 'Add a new Play entry for the #2PlaysAMonth event.'
 title: '[#2PlaysAMonth]: '
 labels: ['#2PlaysAMonth']
 body:
+  - type: checkboxes
+    id: read-guidelines
+    attributes:
+      label: Contributor Guidelines
+      description: Please confirm that you have read the [Contributor Guidelines and Discussion](https://github.com/reactplay/react-play/discussions/1598) before submitting this issue or PR.
+      options:
+        - label: I have read the guidelines and discussion
+          required: true
+
   - type: markdown
     attributes:
       value: |
@@ -35,7 +44,6 @@ body:
           required: true
         - label: I want to work on this issue
         - label: I am a Hacktoberfest contributor
-
 
   - type: checkboxes
     id: terms

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,8 +1,17 @@
-name: "\U0001F41B [Bug report]:"
+name: "🐛 [Bug report]:"
 description: Create a report to help us improve
-title: "\U0001F41B [Bug report]: "
-labels: ["bug","🛠 goal: fix", "🚦status: awaiting triage", "💻 aspect: code"]
+title: "🐛 [Bug report]: "
+labels: ["bug", "🛠 goal: fix", "🚦status: awaiting triage", "💻 aspect: code"]
 body:
+  - type: checkboxes
+    id: read-guidelines
+    attributes:
+      label: Contributor Guidelines
+      description: Please confirm that you have read the [Contributor Guidelines and Discussion](https://github.com/reactplay/react-play/discussions/1598) before submitting this issue or PR.
+      options:
+        - label: I have read the guidelines and discussion
+          required: true
+
   - type: markdown
     attributes:
       value: |
@@ -15,6 +24,7 @@ body:
       description: Tell us what you see!
     validations:
       required: true
+
   - type: textarea
     id: reproduce-step
     attributes:
@@ -54,10 +64,11 @@ body:
       label: Mobile (Please provide your device information)
       description: |
         examples:
-           - **Device**: [e.g. iPhone6]
-           - **OS**: [e.g. iOS8.1]
-           - **Browser** [e.g. stock browser, safari]
-           - **Version** [e.g. 22]
+          - **Device**: [e.g. iPhone6]
+          - **OS**: [e.g. iOS8.1]
+          - **Browser** [e.g. stock browser, safari]
+          - **Version** [e.g. 22]
+
   - type: textarea
     id: screenshot
     attributes:
@@ -69,7 +80,6 @@ body:
     attributes:
       label: Relevant log output
       description: Add any other context about the problem here.
-      
 
   - type: checkboxes
     id: record
@@ -82,8 +92,6 @@ body:
           required: true
         - label: I want to work on this issue
         - label: I am a Hacktoberfest contributor
-
-
 
   - type: checkboxes
     id: terms

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -9,14 +9,24 @@ labels:
     "good first issue"
   ]
 body:
+  - type: checkboxes
+    id: read-guidelines
+    attributes:
+      label: Contributor Guidelines
+      description: Please confirm that you have read the [Contributor Guidelines and Discussion](https://github.com/reactplay/react-play/discussions/1598) before submitting this issue or PR.
+      options:
+        - label: I have read the guidelines and discussion
+          required: true
+
   - type: textarea
     id: improve-docs
     attributes:
-      label: what's wrong with the documentation?
-      description: which things do we need to add?
+      label: What's wrong with the documentation?
+      description: Which things do we need to add?
       placeholder: Add description
     validations:
       required: true
+
   - type: textarea
     id: screenshots
     attributes:
@@ -25,6 +35,7 @@ body:
       placeholder: Add screenshots
     validations:
       required: true
+
   - type: checkboxes
     id: terms
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -3,10 +3,20 @@ description: Suggest an idea for this project
 title: '✨ [Feature request]: '
 labels: ["🚦status: awaiting triage", "💻 aspect: code", "⭐ goal: addition"]
 body:
+  - type: checkboxes
+    id: read-guidelines
+    attributes:
+      label: Contributor Guidelines
+      description: Please confirm that you have read the [Contributor Guidelines and Discussion](https://github.com/reactplay/react-play/discussions/1598) before submitting this issue or PR.
+      options:
+        - label: I have read the guidelines and discussion
+          required: true
+
   - type: markdown
     attributes:
       value: |
         Thanks for taking the time for issuing a feature request!
+
   - type: textarea
     id: feature-reason
     attributes:
@@ -55,7 +65,6 @@ body:
           required: true
         - label: I want to work on this issue
         - label: I am a Hacktoberfest contributor
-
 
   - type: checkboxes
     id: terms

--- a/.github/ISSUE_TEMPLATE/new-play.yml
+++ b/.github/ISSUE_TEMPLATE/new-play.yml
@@ -1,8 +1,17 @@
 name: New Play
 description: Add a New Play Request
 title: '[Add a Play]: '
-labels: ["play request","🚦status: awaiting triage", "💻 aspect: code" ]
+labels: ["play request", "🚦status: awaiting triage", "💻 aspect: code"]
 body:
+  - type: checkboxes
+    id: read-guidelines
+    attributes:
+      label: Contributor Guidelines
+      description: Please confirm that you have read the [Contributor Guidelines and Discussion](https://github.com/reactplay/react-play/discussions/1598) before submitting this issue or PR.
+      options:
+        - label: I have read the guidelines and discussion
+          required: true
+
   - type: markdown
     attributes:
       value: |

--- a/.github/ISSUE_TEMPLATE/refactor.yml
+++ b/.github/ISSUE_TEMPLATE/refactor.yml
@@ -1,8 +1,17 @@
 name: Refactor Code 🔧
 description: Use this label for code refactoring tasks.
 title: "[Refactor] <write what you want to add>"
-labels: ["🛠 goal: refactor", "🚦status: awaiting triage","💻 aspect: code"]
+labels: ["🛠 goal: refactor", "🚦status: awaiting triage", "💻 aspect: code"]
 body:
+  - type: checkboxes
+    id: read-guidelines
+    attributes:
+      label: Contributor Guidelines
+      description: Please confirm that you have read the [Contributor Guidelines and Discussion](https://github.com/reactplay/react-play/discussions/1598) before submitting this issue or PR.
+      options:
+        - label: I have read the guidelines and discussion
+          required: true
+
   - type: input
     id: refactor_input
     attributes:
@@ -11,6 +20,7 @@ body:
       placeholder: "For example - src/common"
     validations:
       required: true
+
   - type: textarea
     id: refactor_description
     attributes:
@@ -18,6 +28,7 @@ body:
       description: "Describe what improvements can be made in the codebase without introducing breaking changes."
     validations:
       required: true
+
   - type: checkboxes
     id: refactor_terms
     attributes:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,10 @@
+> **Before creating this PR, please confirm the following:**
+> - I have read the [ReactPlay Contributor Guidelines and Discussion](https://github.com/reactplay/react-play/discussions/1598)
+> - I have reviewed the [ReactPlay Code Review Checklist](https://github.com/reactplay/react-play/wiki/ReactPlay-Code-Review-Checklist)
+> - I have tested my changes locally and verified there are no new warnings or errors
+
+---
+
 > First thing, PLEASE READ THIS: [ReactPlay Code Review Checklist](https://github.com/reactplay/react-play/wiki/ReactPlay-Code-Review-Checklist)
 
 # Description


### PR DESCRIPTION
## Description

This PR adds a required Contributor Guidelines confirmation checkbox to all issue templates and the pull request template.  
This ensures that contributors have read the [Contributor Guidelines and Discussion](https://github.com/reactplay/react-play/discussions/1598) before submitting issues or PRs.

Templates updated:
- bug_report.yml
- feature_request.yml
- docs.yml
- 2playsAmonth.yml
- newplay.yml
- refactor.yml
- pull_request_template.md

Fixes #1599 

## Type of change

- [x] This change requires a documentation update

## How Has This Been Tested?

- Verified that all .yml templates include the new checkbox at the top.
- No functional code changes were made.

## Checklist:

- [x] I have performed a self-review of my own changes
- [x] I have added description and verified templates
- [x] All changes are ready for review

## Screenshots or example output

- Not applicable; template changes only
