### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/contributions.yml
+++ b/.github/workflows/contributions.yml
@@ -1,4 +1,6 @@
 name: Add contributors
+permissions:
+  issues: write
 on:
   pull_request_target:
     types:


### PR DESCRIPTION
Potential fix for [https://github.com/reactplay/react-play/security/code-scanning/14](https://github.com/reactplay/react-play/security/code-scanning/14)

To address the problem, add a `permissions` block specifying the least privilege required. At the root level of `.github/workflows/contributions.yml`, add:

```yaml
permissions:
  issues: write
```

This limits the workflow’s GITHUB_TOKEN so it can only write/read issue and PR comments, which is all that’s needed for this workflow (which creates comments on issues/PRs). Add this block directly beneath the `name:` and above the `on:` key to affect all jobs in the workflow (since there’s only one job).

No further changes or imports are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
