### PR TITLE
feat: update leaderboard UI with top 3 highlights and trophy icons

### DIFF
--- a/src/common/playleaderboard/TopPlayCreators.jsx
+++ b/src/common/playleaderboard/TopPlayCreators.jsx
@@ -4,22 +4,38 @@ import TableCell from '@mui/material/TableCell';
 import TableContainer from '@mui/material/TableContainer';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
+import EmojiEventsIcon from '@mui/icons-material/EmojiEvents';
 import './leaderBoard.css';
 
 const TopPlayCreators = ({ topPlayCreators }) => {
-  const profilePicture = (name, avatarUrl) => {
-    return (
-      <div className="flex flex-row items-center gap-4">
-        <img
-          alt={name}
-          className="rounded-full border-solid h-8 w-8"
-          src={avatarUrl}
-          title={name}
-        />
-        <div className="leaderboard-table-cell">{name}</div>
-      </div>
-    );
+  const getRankIcon = (rank) => {
+    if (rank === 1) {
+      return <EmojiEventsIcon className="gold-trophy" fontSize="small" />;
+    }
+
+    if (rank === 2) {
+      return <EmojiEventsIcon className="silver-trophy" fontSize="small" />;
+    }
+
+    if (rank === 3) {
+      return <EmojiEventsIcon className="bronze-trophy" fontSize="small" />;
+    }
+
+    return null;
   };
+
+  const profilePicture = (name, avatarUrl, rank) => (
+    <div className="flex flex-row items-center gap-3">
+      {getRankIcon(rank)}
+      <img
+        alt={name}
+        className="h-8 w-8 rounded-full border-solid rank-avatar"
+        src={avatarUrl}
+        title={name}
+      />
+      <div className="leaderboard-table-cell">{name}</div>
+    </div>
+  );
 
   return (
     <TableContainer className="leaderboard-container">
@@ -30,24 +46,34 @@ const TopPlayCreators = ({ topPlayCreators }) => {
               Name
             </TableCell>
             <TableCell align="center" className="leaderboard-table-header">
-              Number of plays
+              Number of Plays
             </TableCell>
           </TableRow>
         </TableHead>
         <TableBody>
-          {topPlayCreators.map((creator) => (
-            <TableRow
-              key={creator.displayName}
-              sx={{ '&:last-child td, &:last-child th': { border: 0 } }}
-            >
-              <TableCell align="left" className="leaderboard-table-cell" component="th" scope="row">
-                {profilePicture(creator.displayName, creator.avatarUrl)}
-              </TableCell>
-              <TableCell align="center" className="leaderboard-table-cell">
-                {creator.count}
-              </TableCell>
-            </TableRow>
-          ))}
+          {topPlayCreators.map((creator, index) => {
+            const rank = index + 1;
+
+            return (
+              <TableRow
+                className={`rank-${rank}`}
+                key={creator.displayName}
+                sx={{ '&:last-child td, &:last-child th': { border: 0 } }}
+              >
+                <TableCell
+                  align="left"
+                  className="leaderboard-table-cell"
+                  component="th"
+                  scope="row"
+                >
+                  {profilePicture(creator.displayName, creator.avatarUrl, rank)}
+                </TableCell>
+                <TableCell align="center" className="leaderboard-table-cell">
+                  {creator.count}
+                </TableCell>
+              </TableRow>
+            );
+          })}
         </TableBody>
       </Table>
     </TableContainer>

--- a/src/common/playleaderboard/leaderBoard.css
+++ b/src/common/playleaderboard/leaderBoard.css
@@ -5,11 +5,12 @@
   margin-top: 10px;
   margin-bottom: 20px;
   padding: 5px 2rem 1rem 2rem;
-  --tw-shadow: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
+  --tw-shadow: 0 20px 25px -5px rgb(0 0 0 / 0.1),
+    0 8px 10px -6px rgb(0 0 0 / 0.1);
   --tw-shadow-colored: 0 20px 25px -5px var(--tw-shadow-color),
     0 8px 10px -6px var(--tw-shadow-color);
-  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000),
-    var(--tw-shadow);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000),
+    var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
 .leaderboard-table-cell {
@@ -24,6 +25,8 @@
 .leaderboard-heading {
   font-family: var(--ff-accent);
   font-size: 32px !important;
+  text-align: center;
+  margin-bottom: 12px;
 }
 
 .leaderboard-text {
@@ -36,4 +39,41 @@
   align-items: center;
   justify-content: center;
   height: 100vh;
+}
+
+/* Trophy colors */
+.gold-trophy {
+  color: #ffd700;
+}
+.silver-trophy {
+  color: #c0c0c0;
+}
+.bronze-trophy {
+  color: #cd7f32;
+}
+
+/* Highlight top 3 rows */
+.rank-1 {
+  background: rgba(255, 215, 0, 0.15);
+  font-weight: bold;
+}
+.rank-2 {
+  background: rgba(192, 192, 192, 0.15);
+}
+.rank-3 {
+  background: rgba(205, 127, 50, 0.15);
+}
+
+/* Avatar borders */
+.rank-avatar {
+  border: 2px solid transparent;
+}
+.rank-1 .rank-avatar {
+  border-color: #ffd700;
+}
+.rank-2 .rank-avatar {
+  border-color: #c0c0c0;
+}
+.rank-3 .rank-avatar {
+  border-color: #cd7f32;
 }


### PR DESCRIPTION
> > **Before creating this PR, please confirm the following:**

> - I have read the [ReactPlay Contributor Guidelines and Discussion](https://github.com/reactplay/react-play/discussions/1598)
> - I have reviewed the [ReactPlay Code Review Checklist](https://github.com/reactplay/react-play/wiki/ReactPlay-Code-Review-Checklist)
> - I have tested my changes locally and verified there are no new warnings or errors

---

> First thing, PLEASE READ THIS: [ReactPlay Code Review Checklist](https://github.com/reactplay/react-play/wiki/ReactPlay-Code-Review-Checklist)

# Description

Improved the **Leaderboard Page UI** by highlighting the top 3 creators.

- Added trophy icons 🥇 🥈 🥉 for ranks 1, 2, and 3.
- Styled rows and avatars in `leaderBoard.css` with gold, silver, and bronze highlights.
- Makes the leaderboard more engaging and rewarding for top-ranked creators.

**Fixes #1611**

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Ran the app locally with `npm start`.
- Verified that the leaderboard page displays correctly.
- Confirmed trophies and styles are applied to ranks 1–3.
- Checked there are no new warnings or linting errors.

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas (N/A)
- [ ] I have made corresponding changes to the documentation (N/A)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (UI verified manually)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules (N/A)

# Screenshots or example output
### Before
<img width="679" height="669" alt="Screenshot 2025-10-10 111948" src="https://github.com/user-attachments/assets/79a2754e-2f27-412f-895b-932d3d49feb5" />

### After
<img width="706" height="722" alt="Screenshot 2025-10-10 112049" src="https://github.com/user-attachments/assets/aa8954ed-3426-4123-867d-074385502af9" />

