### PR TITLE
fix(common): close mobile nav drawer when tapping outside overlay

### DIFF
--- a/src/common/header/HeaderNav.jsx
+++ b/src/common/header/HeaderNav.jsx
@@ -121,8 +121,16 @@ const HeaderNav = ({ showBrowse }) => {
       >
         <span className="navbar-toggler-icon" />
       </button>
-      <div className={showToggleMenu ? 'navbar-collapse show' : 'navbar-collapse'}>
-        <ul className="header-links" data-testid="header-links-container">
+      <div
+        className={showToggleMenu ? 'navbar-collapse show' : 'navbar-collapse'}
+        role="presentation"
+        onClick={() => setShowToggleMenu(false)}
+      >
+        <ul
+          className="header-links"
+          data-testid="header-links-container"
+          onClick={(e) => e.stopPropagation()}
+        >
           <li className="menu-closer">
             <button
               className="navbar-closer"

--- a/src/common/header/header.css
+++ b/src/common/header/header.css
@@ -101,6 +101,51 @@
   display: none;
 }
 
+@media screen and (max-width: 1217px) {
+  .navbar-collapse {
+    display: block !important;
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    visibility: hidden;
+    pointer-events: none;
+  }
+
+  .navbar-collapse:before {
+    content: '';
+    background-color: var(--color-neutral-90);
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 0;
+    opacity: 0;
+    cursor: pointer;
+    transition: opacity 0.3s ease;
+  }
+
+  .navbar-collapse .header-links {
+    transform: translateX(100%);
+    transition: transform 0.3s ease;
+  }
+
+  .navbar-collapse.show {
+    visibility: visible;
+    pointer-events: auto;
+  }
+
+  .navbar-collapse.show:before {
+    opacity: 60%;
+  }
+
+  .navbar-collapse.show .header-links {
+    transform: translateX(0);
+  }
+}
+
 @media (min-width: 1217px) {
   .navbar-toggler {
     display: none;
@@ -176,28 +221,7 @@
 }
 
 @media screen and (max-width: 1217px) {
-  .navbar-collapse.show {
-    display: block;
-    position: fixed;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-  }
-
-  .navbar-collapse.show:before {
-    content: '';
-    background-color: var(--color-neutral-90);
-    position: fixed;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    z-index: 0;
-    opacity: 60%;
-  }
-
-  .navbar-collapse.show .header-links {
+  .navbar-collapse .header-links {
     position: absolute;
     top: 0;
     right: 0;
@@ -214,14 +238,11 @@
 
   .navbar-collapse.show .header-links {
     align-items: stretch;
+    grid-gap: 0.2rem;
   }
 
   .navbar-collapse .menu-closer {
     display: block;
-  }
-
-  .navbar-collapse.show .header-links {
-    grid-gap: 0.2rem;
   }
 
   .header-links > li.menu-spacer {


### PR DESCRIPTION
## Description
Fixes #1659

The mobile nav drawer did not close when tapping outside the drawer panel on mobile devices.

## Changes
- Added `onClick` handler on the `navbar-collapse` overlay to close the drawer when tapping outside
- Added `e.stopPropagation()` on `header-links` to prevent clicks inside the drawer from closing it
- Added smooth slide (`translateX`) and fade (`opacity`) CSS transitions for open/close animation
- Replaced `display: none/block` with `visibility` + `pointer-events` to enable CSS transitions
- Added `cursor: pointer` on overlay for better UX affordance

## Files Changed
- `src/common/header/HeaderNav.jsx` - Added click handlers for overlay close behavior
- `src/common/header/header.css` - Added transition animations, restructured mobile nav styles

## Testing
1. Open the app on mobile or resize browser below 1217px
2. Tap the hamburger menu to open the nav drawer
3. Tap the dark overlay area outside the drawer
4. Drawer smoothly slides closed and overlay fades out
5. Clicking inside the drawer does NOT close it
6. The X close button still works as before

## Before
- Tapping overlay outside drawer: nothing happened
- Opening/closing: instant show/hide, no animation

## After
- Tapping overlay outside drawer: drawer closes with smooth animation
- Opening: drawer slides in from right, overlay fades in (0.3s ease)
- Closing: drawer slides out to right, overlay fades out (0.3s ease)